### PR TITLE
[삭제] RequestDto Url,RecruitmentMember Schema 삭제

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/dto/PostRequestDto.java
+++ b/src/main/java/com/studycollaboproject/scope/dto/PostRequestDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @ToString
@@ -25,8 +26,6 @@ public class PostRequestDto {
     private String techStack;
     @Schema(description = "총 인원")
     private Integer totalMember;
-    @Schema(description = "현재 구한 인원")
-    private Integer recruitmentMember;
     @Schema(description = "프로젝트 상태")
     private String projectStatus;
     //    private String recommendationAgree;
@@ -37,9 +36,26 @@ public class PostRequestDto {
 //    private List<Team> teamList;
     @Schema(description = "글쓰기시 프로젝트 기술 스택")
     private List<String> techStackList;
-    @Schema(description = "백엔드 Url")
-    private String backUrl;
-    @Schema(description = "프론트엔드 Url")
-    private String frontUrl;
+
+
+    public PostRequestDto(String title,
+                          String summary,
+                          String contents,
+                          List<String> techStackList,
+                          String techStack,
+                          Integer totalMember,
+                          String projectStatus,
+                          String startDate,
+                          String endDate) {
+        this.title = title;
+        this.summary = summary;
+        this.contents = contents;
+        this.techStack = techStack;
+        this.techStackList = techStackList;
+        this.totalMember = totalMember;
+        this.projectStatus = projectStatus;
+        this.startDate = LocalDate.parse(startDate);
+        this.endDate = LocalDate.parse(endDate);
+    }
 
 }

--- a/src/main/java/com/studycollaboproject/scope/model/Post.java
+++ b/src/main/java/com/studycollaboproject/scope/model/Post.java
@@ -84,7 +84,6 @@ public class Post extends Timestamped {
         this.contents = postRequestDto.getContents();
         this.totalMember = postRequestDto.getTotalMember();
         this.user = user;
-        this.recruitmentMember = postRequestDto.getRecruitmentMember();
         this.projectStatus = ProjectStatus.projectStatusOf(postRequestDto.getProjectStatus());
 
     }
@@ -97,10 +96,8 @@ public class Post extends Timestamped {
         this.summary = postRequestDto.getSummary();
         this.contents = postRequestDto.getContents();
         this.totalMember = postRequestDto.getTotalMember();
-        this.recruitmentMember = postRequestDto.getRecruitmentMember();
         this.projectStatus = ProjectStatus.projectStatusOf(postRequestDto.getProjectStatus());
-        this.backUrl = postRequestDto.getBackUrl();
-        this.frontUrl = postRequestDto.getFrontUrl();
+
     }
 
     public void setUrl(String frontUrl, String backUrl) {


### PR DESCRIPTION
## 개요
RequestDto Url,RecruitmentMember Schema 삭제

## 작업내용
- RequestDto로 받아올 내용이 아니라고 판단하여  RequestDto내 Url, RecruitmentMember Schema와 Post 내의RequestDto로 받아오는 Url, RecruitmentMember 부분을삭제하였습니다.

## 주의사항
- 
