### PR TITLE
[추가] 사용자 탈퇴 로직 추가

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/controller/TestDataRunner.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/TestDataRunner.java
@@ -1,7 +1,10 @@
 package com.studycollaboproject.scope.controller;
 
+import com.studycollaboproject.scope.dto.TestUserSetupDto;
 import com.studycollaboproject.scope.model.TotalResult;
+import com.studycollaboproject.scope.model.User;
 import com.studycollaboproject.scope.repository.TotalResultRepository;
+import com.studycollaboproject.scope.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class TestDataRunner implements ApplicationRunner {
 
     private final TotalResultRepository totalResultRepository;
+    private final UserRepository userRepository;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -22,13 +26,12 @@ public class TestDataRunner implements ApplicationRunner {
                 for (String s1 : propersityTypeList) {
                     TotalResult totalResult = new TotalResult(s, s1);
                     totalResultRepository.save(totalResult);
-
-
                 }
-
             }
-
-
         }
+
+
+        User user = new User(new TestUserSetupDto());
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
@@ -132,4 +132,17 @@ public class UserRestController {
         log.info("POST, [{}], /api/bookmark/{}", MDC.get("UUID"), postId);
         return userService.bookmarkCheck(postId,userDetails.getSnsId());
     }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("api/user/{userId}")
+    public ResponseDto deleteUser(@Parameter(description = "탈퇴하려는 회원 ID",in = ParameterIn.PATH) @PathVariable Long userId,
+                                  @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails){
+        log.info("POST, [{}], /api/user/{}", MDC.get("UUID"), userId);
+        if (userDetails.getUser().getId().equals(userId)){
+            return userService.deleteUser(userDetails.getUser());
+
+        }else {
+            throw new RestApiException(ErrorCode.NO_AUTHORIZATION_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/studycollaboproject/scope/dto/TestUserSetupDto.java
+++ b/src/main/java/com/studycollaboproject/scope/dto/TestUserSetupDto.java
@@ -1,0 +1,27 @@
+package com.studycollaboproject.scope.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public
+class TestUserSetupDto{
+    private String snsId;
+    private String nickname;
+    private String memberPropensityType;
+    private String userPropensityType;
+    private String email;
+
+
+    public TestUserSetupDto(){
+        this.email = "unknown";
+        this.memberPropensityType = "unknown";
+        this.nickname = "unknown";
+        this.userPropensityType = "unknown";
+        this.snsId = "unknown";
+    }
+}

--- a/src/main/java/com/studycollaboproject/scope/model/Post.java
+++ b/src/main/java/com/studycollaboproject/scope/model/Post.java
@@ -97,6 +97,10 @@ public class Post extends Timestamped {
 
     }
 
+    public void deleteUser(User user){
+        this.user = user;
+    }
+
     public void setUrl(String frontUrl, String backUrl) {
         this.frontUrl = frontUrl;
         this.backUrl = backUrl;

--- a/src/main/java/com/studycollaboproject/scope/model/User.java
+++ b/src/main/java/com/studycollaboproject/scope/model/User.java
@@ -2,6 +2,7 @@ package com.studycollaboproject.scope.model;
 
 import com.studycollaboproject.scope.dto.SignupRequestDto;
 import com.studycollaboproject.scope.dto.SignupTestDto;
+import com.studycollaboproject.scope.dto.TestUserSetupDto;
 import com.studycollaboproject.scope.util.Timestamped;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -76,6 +77,15 @@ public class User extends Timestamped {
         this.userPropensityType = userPropensityType;
         this.memberPropensityType = memberPropensityType;
         this.nickname = nickname;
+    }
+
+    public User(TestUserSetupDto testUserSetupDto) {
+        this.nickname = testUserSetupDto.getNickname();
+        this.userPropensityType = testUserSetupDto.getUserPropensityType();
+        this.email = testUserSetupDto.getEmail();
+        this.snsId = testUserSetupDto.getSnsId();
+        this.memberPropensityType = testUserSetupDto.getMemberPropensityType();
+
     }
 
     public void addTechStackList(List<TechStack> techStackList){

--- a/src/main/java/com/studycollaboproject/scope/repository/ApplicantRepository.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/ApplicantRepository.java
@@ -12,4 +12,6 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     Optional<Applicant> findByUserAndPost(User user, Post post);
     void deleteAllByPost(Post post);
     List<Applicant> findAllByPost(Post post);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/studycollaboproject/scope/repository/BookmarkRepository.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/BookmarkRepository.java
@@ -16,4 +16,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByUserAndPost(User user, Post post);
 
 
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/studycollaboproject/scope/repository/PostRepository.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/PostRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndUser(Long postId, User user);
     List<Post> findByUserMemberPropensityType(String memberPropensityType);
+    List<Post> findAllByUser(User user);
 }

--- a/src/main/java/com/studycollaboproject/scope/repository/TeamRepository.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/TeamRepository.java
@@ -18,4 +18,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findAllByPost(Post post);
 
     void deleteAllByPost(Post post);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/studycollaboproject/scope/repository/UserRepository.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findBySnsId(String snsId);
 
     Optional<User> findByNickname(String nickname);
+
+    User findByUserPropensityType(String userPropensityType);
 }


### PR DESCRIPTION
## 개요

사용자 탈퇴 로직 추가

## 작업내용
- 탈퇴한 사용자를 unknwon 객체로 바꿔주기 위해 `testUserSetupDto` 추가
- 서버가 구동될 때 unknwon 객체를 user 테이블에 저장하기 위해 `TestDataRunner`에 로직 추가
- `UserRestController`에 탈퇴 api 추가
- User에 `testUserSetupDto`를 받는 생성자 추가
- `UserService`에 User 연관관계 삭제 및 탈퇴한 사용자의 Post 게시자를 unknown으로 변환하는 로직 추가
- `postRepository` , `TeamRepository` , `UserRepository`, `BookmarkRepository`, `ApplicantRepository`에 회원 탈퇴 관련된 메소드 추가

## 주의사항
- 
