### PR TITLE
Feature/user

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/controller/TestDataRunner.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/TestDataRunner.java
@@ -30,8 +30,10 @@ public class TestDataRunner implements ApplicationRunner {
             }
         }
 
+        if(!userRepository.findByUserPropensityType("unknown").getSnsId().equals("unknown")){
+            User user = new User(new TestUserSetupDto());
+            userRepository.save(user);
+        }
 
-        User user = new User(new TestUserSetupDto());
-        userRepository.save(user);
     }
 }

--- a/src/main/java/com/studycollaboproject/scope/dto/PostResponseDto.java
+++ b/src/main/java/com/studycollaboproject/scope/dto/PostResponseDto.java
@@ -41,6 +41,10 @@ public class PostResponseDto {
     private String frontUrl;
     @Schema(description = "프로젝트 백앤드 Repository URL")
     private String backUrl;
+    @Schema(description = "작성자 성향 정보")
+    private String propensityType;
+    @Schema(description = "작성자 닉네임")
+    private String nickname;
 
     public PostResponseDto(Post post) {
         this.postId = post.getId();
@@ -59,6 +63,8 @@ public class PostResponseDto {
         this.projectStatus = post.getProjectStatus().getProjectStatus();
         this.frontUrl = post.getFrontUrl();
         this.backUrl = post.getBackUrl();
+        this.propensityType = post.getUser().getUserPropensityType();
+        this.nickname = post.getUser().getNickname();
     }
 
     public PostResponseDto(Post post,boolean bookmarkChecked) {
@@ -79,5 +85,7 @@ public class PostResponseDto {
         this.projectStatus = post.getProjectStatus().getProjectStatus();
         this.frontUrl = post.getFrontUrl();
         this.backUrl = post.getBackUrl();
+        this.propensityType = post.getUser().getUserPropensityType();
+        this.nickname = post.getUser().getNickname();
     }
 }


### PR DESCRIPTION
## 개요
unknown user가 있을 때 TestDataRunner에서 다시 생성되지 않게 수정
PostResponseDto에 propensityType, nickname 추가

## 작업내용
- unknown user가 있을 때 TestDataRunner에서 다시 생성되지 않게 수정 (충돌 해결)
- PostResponseDto에 propensityType, nickname 추가

## 주의사항
- 충돌시 
```
 if(userRepository.findBySnsId("unknown").isEmpty()){
            User user = new User(new TestUserSetupDto());
            userRepository.save(user);
        }
