### PR TITLE
[수정] gradle.yml s3버킷으로 전달

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,8 @@ on:
   
 jobs:
   build:
-
+  #build 이름 설정 (빌드 체크위해서 설정함)
+    name : build
     runs-on: ubuntu-18.04
 
     steps:
@@ -30,3 +31,28 @@ jobs:
       
     - name: Build with Gradle
       run: ./gradlew clean build
+      
+       # 전송할 파일을 담을 디렉토리 생성
+    - name: Make Directory for deliver
+      run: mkdir deploy
+
+      # Jar 파일 Copy
+    - name: Copy Jar
+      run: cp ./build/libs/*.jar ./deploy/
+
+      # 압축파일 형태로 전달(codedeploy는 zip형식만 읽을 수 있음)
+    - name: Make zip file
+      run: zip -r -qq -j ./scope-build.zip ./deploy
+
+      # AWS credentials
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        
+      # S3로 업로드
+    - name: Uploade to AWS S3
+      run: aws s3 cp --region ap-northeast-2 --acl private ./scope-build.zip s3://scope-build/
+
+


### PR DESCRIPTION
EC2연동을 위한 gradle.yml S3 버킷으로 전달

## 개요
EC2연동을 위한 gradle.yml S3 버킷으로 전달

## 작업내용
- EC2연동을 위한 gradle.yml S3 버킷으로 전달

## 주의사항
- 
