### PR TITLE
[추가] 포스트 상세페이지 조회시 조회하는 사용자의 상태 판단 로직 추가

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
@@ -4,7 +4,10 @@ import com.studycollaboproject.scope.dto.*;
 import com.studycollaboproject.scope.exception.ErrorCode;
 import com.studycollaboproject.scope.exception.RestApiException;
 import com.studycollaboproject.scope.model.Post;
+import com.studycollaboproject.scope.model.User;
+import com.studycollaboproject.scope.model.UserStatus;
 import com.studycollaboproject.scope.security.UserDetailsImpl;
+import com.studycollaboproject.scope.service.ApplicantService;
 import com.studycollaboproject.scope.service.PostService;
 import com.studycollaboproject.scope.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +35,7 @@ public class PostRestController {
 
     private final PostService postService;
     private final TeamService teamService;
+    private final ApplicantService applicantService;
 
     @Operation(summary = "프로젝트 작성")
     @PostMapping("/api/post")
@@ -136,17 +140,29 @@ public class PostRestController {
         log.info("GET, [{}], /api/post/{}", MDC.get("UUID"), postId);
 
         List<MemberListResponseDto> member = teamService.getMember(postId);
-        boolean isTeamStarter = false;
-        boolean isBookmarkChecked = false;
 
+        boolean isBookmarkChecked = false;
+        String userStatus;
         Post post = postService.loadPostByPostId(postId);
+
         if (userDetails != null) {
-            isTeamStarter = postService.isTeamStarter(post,userDetails.getUsername());
-            isBookmarkChecked = postService.isBookmarkChecked(post,userDetails.getUser());
+            User user = userDetails.getUser();
+            if (postService.isTeamStarter(post,user.getSnsId())){
+                userStatus = UserStatus.USER_STATUS_TEAM_STARTER.getUserStatus();
+            }else if (teamService.isMemeber(post,user)){
+                userStatus = UserStatus.USER_STATUS_MEMBER.getUserStatus();
+            }else if (applicantService.isApplicant(post,user)){
+                userStatus = UserStatus.USER_STATUS_APPLICANT.getUserStatus();
+            }else {
+                userStatus = UserStatus.USER_STATUS_USER.getUserStatus();
+            }
+            isBookmarkChecked = postService.isBookmarkChecked(post,user);
+        }else {
+            userStatus = UserStatus.USER_STATUS_ANONYMOUS.getUserStatus();
         }
         PostResponseDto postDetail = new PostResponseDto(post, isBookmarkChecked);
         return new ResponseEntity<>(
-                new ResponseDto("프로젝트 상세 정보 조회 성공", new PostDetailDto(postDetail, member,isTeamStarter, isBookmarkChecked)),
+                new ResponseDto("프로젝트 상세 정보 조회 성공", new PostDetailDto(postDetail, member,userStatus)),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
@@ -133,7 +133,7 @@ public class PostRestController {
 
     }
 
-    @Operation(summary = "프로젝트 상세 정보")
+    @Operation(summary = "프로젝트 상세 조회")
     @GetMapping("/api/post/{postId}")
     public ResponseEntity<Object> getPost(@Parameter(description = "프로젝트 ID", in = ParameterIn.PATH) @PathVariable Long postId,
                                @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/studycollaboproject/scope/dto/PostDetailDto.java
+++ b/src/main/java/com/studycollaboproject/scope/dto/PostDetailDto.java
@@ -13,12 +13,13 @@ public class PostDetailDto {
     private PostResponseDto post;
     @Schema(description = "프로젝트 맴버")
     private List<MemberListResponseDto> members;
-    @Schema(description = "게시글 작성자인지 여부")
-    private boolean isTeamStarter;
+    @Schema(description = "유저 상태")
+    private String userStatus;
 
-    public PostDetailDto(PostResponseDto postDetail, List<MemberListResponseDto> members,boolean isTeamStarter, boolean isBookmarkChecked) {
+
+    public PostDetailDto(PostResponseDto postDetail, List<MemberListResponseDto> members, String userStatus) {
         this.post = postDetail;
         this.members = members;
-        this.isTeamStarter = isTeamStarter;
+        this.userStatus = userStatus;
     }
 }

--- a/src/main/java/com/studycollaboproject/scope/exception/ErrorCode.java
+++ b/src/main/java/com/studycollaboproject/scope/exception/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode {
     ALREADY_ASSESSMENT_ERROR("이미 평가를 완료했습니다."),
     TOKEN_EXPRIRATOION_ERROR("로그인 정보가 만료되었습니다."),
     ALREADY_STARTED_ERROR("모집중인 프로젝트가 아닙니다."),
-    NO_RECRUITMENT_ERROR("이미 진행중인 프로젝트 프로젝트입니다.")
+    NO_RECRUITMENT_ERROR("이미 진행중인 프로젝트입니다.")
     ;
 
     private String message;

--- a/src/main/java/com/studycollaboproject/scope/model/UserStatus.java
+++ b/src/main/java/com/studycollaboproject/scope/model/UserStatus.java
@@ -1,0 +1,16 @@
+package com.studycollaboproject.scope.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserStatus {
+    USER_STATUS_USER("user"),
+    USER_STATUS_APPLICANT("applicant"),
+    USER_STATUS_MEMBER("member"),
+    USER_STATUS_ANONYMOUS("anonymous"),
+    USER_STATUS_TEAM_STARTER("starter");
+
+    private String userStatus;
+}

--- a/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtension.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtension.java
@@ -2,8 +2,6 @@ package com.studycollaboproject.scope.repository;
 
 import com.studycollaboproject.scope.model.Post;
 import com.studycollaboproject.scope.model.Tech;
-import com.studycollaboproject.scope.model.User;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 

--- a/src/main/java/com/studycollaboproject/scope/service/ApplicantService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/ApplicantService.java
@@ -55,7 +55,7 @@ public class ApplicantService {
     }
 
     @Transactional
-    public boolean cancelApply(String snsId, Long postId) {
+    public void cancelApply(String snsId, Long postId) {
 
         // [예외처리] 요청한 유저의 정보가 탈퇴 등과 같은 이유로 존재하지 않을 때
         User user = userRepository.findBySnsId(snsId).orElseThrow(
@@ -72,8 +72,6 @@ public class ApplicantService {
 
         applicant.deleteApply();
         applicantRepository.delete(applicant);
-
-        return true;
     }
 
     @Transactional

--- a/src/main/java/com/studycollaboproject/scope/service/ApplicantService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/ApplicantService.java
@@ -81,4 +81,8 @@ public class ApplicantService {
         return applicantRepository.findAllByPost(post)
                 .stream().map(MemberListResponseDto::new).collect(Collectors.toCollection(ArrayList::new));
     }
+
+    public boolean isApplicant(Post post, User user) {
+        return applicantRepository.findByUserAndPost(user,post).isPresent();
+    }
 }

--- a/src/main/java/com/studycollaboproject/scope/service/AssessmentService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/AssessmentService.java
@@ -27,13 +27,13 @@ public class AssessmentService {
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new RestApiException(ErrorCode.NO_POST_ERROR)
         );// [예외처리] 팀장이 아니면서 프로젝트 상태가 "동료"가 아닌 경우
-        if (!post.getUser().equals(rater)&&!post.getProjectStatus().equals(ProjectStatus.PROJECT_STATUS_END)){
+        if (!post.getUser().equals(rater) && !post.getProjectStatus().equals(ProjectStatus.PROJECT_STATUS_END)) {
             throw new RestApiException(ErrorCode.NO_AUTHORIZATION_ERROR);
         }
 
         List<Team> teamList = teamRepository.findAllByPost(post);
         List<String> userTypeList = new ArrayList<>();
-        List<User> userList=new ArrayList<>();
+        List<User> userList = new ArrayList<>();
         Long teamUserId;
 
         for (Long userId : userIds) {
@@ -46,6 +46,7 @@ public class AssessmentService {
                 }
                 team.getPost().updateStatus("종료");
                 teamUserId = team.getUser().getId();
+                //
                 if (teamUserId.equals(userId) && !teamUserId.equals(rater.getId())) {
                     userList.add(team.getUser());
                     userTypeList.add(team.getUser().getUserPropensityType());
@@ -55,7 +56,7 @@ public class AssessmentService {
         }
         String raterType = rater.getUserPropensityType();
         getAssessmentResult(raterType, userTypeList);
-        return new MailDto(userList,post);
+        return new MailDto(userList, post);
 
     }
 

--- a/src/main/java/com/studycollaboproject/scope/service/TeamService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/TeamService.java
@@ -60,4 +60,9 @@ public class TeamService {
         } else throw new RestApiException(ErrorCode.NO_RECRUITMENT_ERROR);
 
     }
+
+    public boolean isMemeber(Post post, User user) {
+        return teamRepository.findByUserAndPost(user,post).isPresent();
+
+    }
 }


### PR DESCRIPTION
## 개요
포스트 상세페이지 조회시 조회하는 사용자의 상태 판단 로직 추가
api 명세 기능 설명과 스웨거 설명 동일하게 수정

## 작업내용
- 게시자인지 판단하는 로직 수정
- 팀의 맴버인지 판단하는 로직 추가
- 지원자인지 판단하는 로직 추가

## 주의사항
- 
