### PR TITLE
[수정] 모집 정원 초과 시 팀원 수락 불가 수정, 마이페이지 모집 현황 분리

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/config/WebConfig.java
+++ b/src/main/java/com/studycollaboproject/scope/config/WebConfig.java
@@ -1,8 +1,8 @@
 package com.studycollaboproject.scope.config;
 
 import com.studycollaboproject.scope.filter.LogFilter;
-import com.studycollaboproject.scope.security.ExceptionHandlerFilter;
-import com.studycollaboproject.scope.security.JwtAuthenticationFilter;
+import com.studycollaboproject.scope.filter.ExceptionHandlerFilter;
+import com.studycollaboproject.scope.filter.JwtAuthenticationFilter;
 import com.studycollaboproject.scope.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/src/main/java/com/studycollaboproject/scope/controller/TeamRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/TeamRestController.java
@@ -51,6 +51,7 @@ public class TeamRestController {
         String snsId = Optional.ofNullable(userDetails).orElseThrow(
                 () -> new NoAuthException(ErrorCode.NO_AUTHENTICATION_ERROR)
         ).getSnsId();
+
         //로그인 사용자 정보 불러오기
         User user = userService.loadUserBySnsId(snsId);
         //로그인 사용자가 해당 프로젝트의 생성자 인지 확인

--- a/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
@@ -20,12 +20,12 @@ import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.mail.MessagingException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -41,20 +41,16 @@ public class UserRestController {
 
     @Operation(summary = "마이 페이지")
     @GetMapping("/api/user/{userId}")
-    public ResponseEntity<Object> getMyPage(@Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<Object> getMyPage(@Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
                                             @Parameter(description = "조회하고자 하는 사용자의 ID", in = ParameterIn.PATH) @PathVariable Long userId) {
         log.info("GET, [{}], /api/user", MDC.get("UUID"));
         User user = userService.loadUserByUserId(userId);
-        MypageResponseDto responseDto;
-        if (userDetails == null) {
-            responseDto = postService.getMyPostList(user, "");
-        } else {
-            responseDto = postService.getMyPostList(user, userDetails.getUsername());
-        }
 
+        String snsId = Optional.ofNullable(userDetails).map(UserDetailsImpl::getSnsId).orElse("");
+        MypageResponseDto responseDto = postService.getMyPostList(user, snsId);
 
         return new ResponseEntity<>(
-                new ResponseDto("", responseDto),
+                new ResponseDto("회원 정보 조회 성공", responseDto),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/studycollaboproject/scope/dto/MypageResponseDto.java
+++ b/src/main/java/com/studycollaboproject/scope/dto/MypageResponseDto.java
@@ -1,6 +1,7 @@
 package com.studycollaboproject.scope.dto;
 
 
+import com.studycollaboproject.scope.model.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -13,6 +14,9 @@ public class MypageResponseDto {
     private UserResponseDto user;
     @Schema(description = "북마크된 포스트 리스트")
     private List<PostResponseDto> bookmark;
+
+    @Schema(description = "대기상태 포스트 리스트")
+    private List<PostResponseDto> ready;
     @Schema(description = "모집중인 포스트 리스트")
     private List<PostResponseDto> recruitment = new ArrayList<>();
     @Schema(description = "진행중인 포스트 리스트")
@@ -22,8 +26,9 @@ public class MypageResponseDto {
     @Schema(description = "사용자의 마이페이지인지 판단")
     private Boolean isMyMypage;
 
-    public MypageResponseDto(List<PostResponseDto> includedList, List<PostResponseDto> myBookmarkList, UserResponseDto userResponseDto, Boolean equals) {
+    public MypageResponseDto(List<PostResponseDto> includedList, List<PostResponseDto> readyPostList, List<PostResponseDto> myBookmarkList, UserResponseDto userResponseDto, Boolean equals) {
         this.bookmark = myBookmarkList;
+        this.ready = readyPostList;
         for (PostResponseDto responseDto : includedList) {
             switch (responseDto.getProjectStatus()) {
                 case "모집중":

--- a/src/main/java/com/studycollaboproject/scope/exception/ErrorCode.java
+++ b/src/main/java/com/studycollaboproject/scope/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     ALREADY_ASSESSMENT_ERROR("이미 평가를 완료했습니다."),
     TOKEN_EXPRIRATOION_ERROR("로그인 정보가 만료되었습니다."),
     ALREADY_STARTED_ERROR("모집중인 프로젝트가 아닙니다."),
-    NO_RECRUITMENT_ERROR("이미 진행중인 프로젝트입니다.")
+    NO_RECRUITMENT_ERROR("이미 진행중인 프로젝트입니다."),
+    NO_EXCEED_MEMBER_ERROR("이미 모집 정원이 가득 찼습니다.")
     ;
 
     private String message;

--- a/src/main/java/com/studycollaboproject/scope/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/studycollaboproject/scope/filter/ExceptionHandlerFilter.java
@@ -1,4 +1,4 @@
-package com.studycollaboproject.scope.security;
+package com.studycollaboproject.scope.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.studycollaboproject.scope.dto.ResponseDto;
@@ -15,6 +15,10 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
+            if(request.getContentLengthLong() > 10000) {
+                errorResponse(response, "Request content exceed limit of 10000 bytes");
+                return ;
+            }
             filterChain.doFilter(request, response);
         } catch (RuntimeException exception) {
             errorResponse(response, exception.getLocalizedMessage());

--- a/src/main/java/com/studycollaboproject/scope/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/studycollaboproject/scope/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
-package com.studycollaboproject.scope.security;
+package com.studycollaboproject.scope.filter;
 
+import com.studycollaboproject.scope.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;

--- a/src/main/java/com/studycollaboproject/scope/filter/LogFilter.java
+++ b/src/main/java/com/studycollaboproject/scope/filter/LogFilter.java
@@ -19,7 +19,6 @@ public class LogFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 //        HttpServletRequest httpRequest = (HttpServletRequest) request;
-
         String uuid = UUID.randomUUID().toString();
         MDC.put("UUID", uuid);
 

--- a/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtension.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtension.java
@@ -19,7 +19,9 @@ public interface PostRepositoryExtension {
 
     List<Post> findAllByPropensityTypeOrderByCreatedAt(String propensity, List<Tech> techList);
 
-    List<Post> findAllByUserSnsId(String snsID);
+    List<Post> findMemberPostByUserSnsId(String snsID);
+
+    List<Post> findReadyPostByUserSnsId(String snsID);
 
     List<Post> findAllBookmarkByUserSnsId(String snsId);
 }

--- a/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtensionImpl.java
+++ b/src/main/java/com/studycollaboproject/scope/repository/PostRepositoryExtensionImpl.java
@@ -92,10 +92,20 @@ public class PostRepositoryExtensionImpl extends QuerydslRepositorySupport imple
     }
 
     @Override
-    public List<Post> findAllByUserSnsId(String snsId) {
+    public List<Post> findMemberPostByUserSnsId(String snsId) {
         JPQLQuery<Post> query = from(post)
-                .where(post.teamList.any().user.snsId.eq(snsId)
-                        .or(post.applicantList.any().user.snsId.eq(snsId)))
+                .where(post.teamList.any().user.snsId.eq(snsId))
+                .leftJoin(post.user, user).fetchJoin()
+                .leftJoin(post.techStackList, QTechStack.techStack).fetchJoin()
+                .orderBy(post.createdAt.desc())
+                .distinct();
+        return query.fetch();
+    }
+
+    @Override
+    public List<Post> findReadyPostByUserSnsId(String snsId) {
+        JPQLQuery<Post> query = from(post)
+                .where(post.applicantList.any().user.snsId.eq(snsId))
                 .leftJoin(post.user, user).fetchJoin()
                 .leftJoin(post.techStackList, QTechStack.techStack).fetchJoin()
                 .orderBy(post.createdAt.desc())

--- a/src/main/java/com/studycollaboproject/scope/service/PostService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/PostService.java
@@ -163,14 +163,16 @@ public class PostService {
     }
 
     public MypageResponseDto getMyPostList(User user, String loginUserSnsId) {
-        List<Post> includePostList = postRepository.findAllByUserSnsId(user.getSnsId());
+        List<Post> includePostList = postRepository.findMemberPostByUserSnsId(user.getSnsId());
+        List<Post> readyPostList = postRepository.findReadyPostByUserSnsId(user.getSnsId());
         List<Post> bookmarkPostList = postRepository.findAllBookmarkByUserSnsId(user.getSnsId());
 //        List<Post> includePostList = postRepository.findAllByUser(user);
 //        List<Post> bookmarkPostList = postRepository.findAllByBookmarkList_User_SnsIdOrderByStartDate(user.getSnsId());
+        List<PostResponseDto> readyList = readyPostList.stream().map(o -> new PostResponseDto(o, true)).collect(Collectors.toList());
         List<PostResponseDto> myBookmarkList = bookmarkPostList.stream().map(o -> new PostResponseDto(o, true)).collect(Collectors.toList());
         List<PostResponseDto> includedList = includePostList.stream().map(o -> new PostResponseDto(o, checkBookmark(o, bookmarkPostList))).collect(Collectors.toList());
 
-        return new MypageResponseDto(includedList, myBookmarkList, new UserResponseDto(user, techStackConverter.convertTechStackToString(user.getTechStackList())), loginUserSnsId.equals(user.getSnsId()));
+        return new MypageResponseDto(includedList, readyList, myBookmarkList, new UserResponseDto(user, techStackConverter.convertTechStackToString(user.getTechStackList())), loginUserSnsId.equals(user.getSnsId()));
     }
 
     public List<String> getPropensityTypeList(String snsId) {

--- a/src/main/java/com/studycollaboproject/scope/service/TeamService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/TeamService.java
@@ -27,6 +27,9 @@ public class TeamService {
         Applicant applicant = applicantRepository.findByUserAndPost(user, post).orElseThrow(
                 () -> new BadRequestException(ErrorCode.NO_APPLICANT_ERROR)
         );
+        if(accept && post.getTotalMember() == post.getRecruitmentMember()){
+            throw new BadRequestException(ErrorCode.NO_EXCEED_MEMBER_ERROR);
+        }
         //대기열에서 삭제
         applicant.deleteApply();
         applicantRepository.delete(applicant);


### PR DESCRIPTION
## 개요
모집 정원 초과 시 팀원 수락 불가 수정, 마이페이지 모집 현황 분리

## 작업내용
- 모집 정원이 가득 찬 상태에서 지원 수락 시 에러 출력
- 마이페이지에서 모집 신청 대기 상태인 프로젝트와 팀으로 포함된 프로젝트가 모집중인 상태인 경우를 분리

## 주의사항
- 
