### PR TITLE
Feature/post

### DIFF
--- a/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
@@ -173,7 +173,6 @@ public class UserRestController {
         log.info("[{}], 이메일 인증 전송, GET, api/user/email, email={}", MDC.get("UUID"), email);
 
         User user = userService.setEmailAuthCode(userDetails.getSnsId());
-
         mailService.authMailSender(email, user);
 
         return new ResponseEntity<>(

--- a/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/UserRestController.java
@@ -172,9 +172,9 @@ public class UserRestController {
                                                       @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) throws MessagingException {
         log.info("[{}], 이메일 인증 전송, GET, api/user/email, email={}", MDC.get("UUID"), email);
 
-        userService.setEmailAuthCode(userDetails.getSnsId());
+        User user = userService.setEmailAuthCode(userDetails.getSnsId());
 
-        mailService.authMailSender(email, userDetails.getUser());
+        mailService.authMailSender(email, user);
 
         return new ResponseEntity<>(
                 new ResponseDto("이메일이 전송되었습니다.", ""),

--- a/src/main/java/com/studycollaboproject/scope/model/User.java
+++ b/src/main/java/com/studycollaboproject/scope/model/User.java
@@ -141,9 +141,9 @@ public class User extends Timestamped {
         this.introduction = userDesc;
     }
 
-//    public void setmailAuthenticationCode(){
-//        this.mailAuthenticationCode = UUID.randomUUID().toString();
-//    }
+    public void setmailAuthenticationCode(){
+        this.mailAuthenticationCode = UUID.randomUUID().toString();
+    }
 
     public void setUuid(String uuid){
         this.mailAuthenticationCode = uuid;

--- a/src/main/java/com/studycollaboproject/scope/service/UserService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/UserService.java
@@ -152,11 +152,11 @@ public class UserService {
     }
 
     @Transactional
-    public void setEmailAuthCode(String snsId) {
+    public User setEmailAuthCode(String snsId) {
         User user = userRepository.findBySnsId(snsId).orElseThrow(()->new BadRequestException(ErrorCode.NO_USER_ERROR));
         String uuid = UUID.randomUUID().toString();
         user.setUuid(uuid);
-
+        return user;
         //        user.setmailAuthenticationCode();
     }
 }

--- a/src/main/java/com/studycollaboproject/scope/service/UserService.java
+++ b/src/main/java/com/studycollaboproject/scope/service/UserService.java
@@ -153,10 +153,9 @@ public class UserService {
 
     @Transactional
     public User setEmailAuthCode(String snsId) {
-        User user = userRepository.findBySnsId(snsId).orElseThrow(()->new BadRequestException(ErrorCode.NO_USER_ERROR));
-        String uuid = UUID.randomUUID().toString();
-        user.setUuid(uuid);
+        User user = userRepository.findBySnsId(snsId).orElseThrow(() -> new BadRequestException(ErrorCode.NO_USER_ERROR));
+        user.setmailAuthenticationCode();
         return user;
-        //        user.setmailAuthenticationCode();
+
     }
 }

--- a/src/main/resources/templates/emailAuthentication.html
+++ b/src/main/resources/templates/emailAuthentication.html
@@ -77,6 +77,7 @@
                                                     <a th:href="@{https://scopewith.com/api/user/auth/email/{userId}(userId = ${userId},code = ${code})}"
                                                        style="background-color:#5065df;border-radius:2px;color:#fff;display:inline-block;padding-bottom:11px;padding-left:30px;padding-right:30px;padding-top:11px;text-align:center;text-decoration:none"
                                                        target="_blank" data-saferedirecturl="">
+
                                         <span style="color:#fff;font-family:sans-serif;font-size:17px;font-weight:600;line-height:28px;text-align:center">이메일 <span
                                                 class="il">인증</span>하기</span>
                                                     </a>


### PR DESCRIPTION
## 개요
이메일 인증 수정

## 작업내용
- 메일 비동기 처리 때문에 uuid를 생성하기 전의 mailAuthenticationCode가 메일에 첨부되어 전송되었다, 메일 전송 호출 함수 인자로 보내던 user의 값을 토큰에서 가져온 user에서 userService uuid 생성 메소드에서 반환된 user로 변환하여 해결하였다.

## 주의사항
- 
