### PR TITLE
[hotfix] 프로젝트 상태 변경 / 프로젝 url 업데이트 컨트롤러에 cache refresh 적용

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,9 @@ name: Spring Boot with Gradle CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
   
 jobs:

--- a/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
+++ b/src/main/java/com/studycollaboproject/scope/controller/PostRestController.java
@@ -127,6 +127,7 @@ public class PostRestController {
 
     @Operation(summary = "프로젝트 상태 변경")
     @PostMapping("/api/post/{postId}/status")
+    @CacheEvict(value = "Post", allEntries=true)
     public ResponseEntity<Object> updatePostStatus(@Parameter(description = "프로젝트 ID", in = ParameterIn.PATH) @PathVariable Long postId,
                                                    @RequestBody ProjectStatusRequestDto requestDto,
                                                    @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -179,6 +180,7 @@ public class PostRestController {
 
     @Operation(summary = "프로젝트 Github URL 업데이트")
     @PostMapping("/api/post/{postId}/url")
+    @CacheEvict(value = "Post", allEntries=true)
     public ResponseEntity<Object> updateUrl(@Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl userDetails,
                                             @RequestBody UrlUpdateRequestDto requestDto,
                                             @Parameter(description = "프로젝트 ID", in = ParameterIn.PATH) @PathVariable Long postId) {


### PR DESCRIPTION
## 개요
[hotfix] 프로젝트 상태 변경 / 프로젝 url 업데이트 컨트롤러에 cache refresh 적용

## 작업내용
- [hotfix] 프로젝트 상태 변경 / 프로젝 url 업데이트 컨트롤러에 cache refresh 적용

## 주의사항
- 
