### PR TITLE
[수정] slf4j 취약점에 따른 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,14 @@ dependencies {
     // 타임리프
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //log
-    implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2:1.16'
-
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2:2.6.1'
+    // 추가
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.15.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.15.0'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
+    implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.32'
     // swagger
     implementation 'org.springdoc:spring-boot-springdoc:3.1.2'
 

--- a/src/main/java/com/studycollaboproject/scope/config/OpenApiConfig.java
+++ b/src/main/java/com/studycollaboproject/scope/config/OpenApiConfig.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OpenApiConfig {
     @Bean
-    public OpenAPI springShopOpenAPI() {
+    public OpenAPI springOpenAPI() {
         Info info = new Info()
                 .title("Scope")
                 .version("V1.0")


### PR DESCRIPTION
## 개요
slf4j 취약점에 따른 버전 변경

## 작업내용
- slf4j 버전 2.15.0 으로 변경
 참고 :[[Spring Boot] 스프링 부트 Log4J2 취약점 조치](https://veneas.tistory.com/entry/Spring-Boot-%EC%8A%A4%ED%94%84%EB%A7%81-%EB%B6%80%ED%8A%B8-Log4J2-%EC%B7%A8%EC%95%BD%EC%A0%90-%EC%A1%B0%EC%B9%98-Log4J2-%EB%B2%84%EC%A0%84-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8)
## 주의사항
- 
